### PR TITLE
Use the new Plugin interface for Flags

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -46,7 +46,8 @@ func (p *plug) Init(ctx context.Context, cfg *viper.Viper, args []string) error 
 	return nil
 }
 
-func (p *plug) BindFlags(flagset *pflag.FlagSet) *pflag.FlagSet {
+func (p *plug) Flags() *pflag.FlagSet {
+	flagset := pflag.NewFlagSet("plugin-template", pflag.ContinueOnError)
 	flags.BindTo(flagset)
 	return flagset
 }


### PR DESCRIPTION
knex/#14 changes the Plugin interface for Flags. This updates the template to follow that interface.